### PR TITLE
Refactor pages to use API services

### DIFF
--- a/frontendTS/src/hooks/useProject.ts
+++ b/frontendTS/src/hooks/useProject.ts
@@ -1,0 +1,21 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Project } from '../models/Project';
+import { getProject } from '../services/api/projectService';
+
+const useProject = (id?: number) => {
+  const [project, setProject] = useState<Project | null>(null);
+
+  const fetchProject = useCallback(async () => {
+    if (!id) return;
+    const data = await getProject(id);
+    setProject(data);
+  }, [id]);
+
+  useEffect(() => {
+    fetchProject();
+  }, [fetchProject]);
+
+  return { project, setProject, fetchProject };
+};
+
+export default useProject;

--- a/frontendTS/src/hooks/useProjects.ts
+++ b/frontendTS/src/hooks/useProjects.ts
@@ -1,0 +1,20 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Project } from '../models/Project';
+import { getProjects } from '../services/api/projectService';
+
+const useProjects = () => {
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  const fetchProjects = useCallback(async () => {
+    const data = await getProjects();
+    setProjects(data.sort((a, b) => a.id! - b.id!));
+  }, []);
+
+  useEffect(() => {
+    fetchProjects();
+  }, [fetchProjects]);
+
+  return { projects, setProjects, fetchProjects };
+};
+
+export default useProjects;

--- a/frontendTS/src/hooks/useSubject.ts
+++ b/frontendTS/src/hooks/useSubject.ts
@@ -1,0 +1,21 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Subject } from '../models/Subject';
+import { getSubject } from '../services/api/subjectService';
+
+const useSubject = (id?: number) => {
+  const [subject, setSubject] = useState<Subject | null>(null);
+
+  const fetchSubject = useCallback(async () => {
+    if (!id) return;
+    const data = await getSubject(id);
+    setSubject(data);
+  }, [id]);
+
+  useEffect(() => {
+    fetchSubject();
+  }, [fetchSubject]);
+
+  return { subject, setSubject, fetchSubject };
+};
+
+export default useSubject;

--- a/frontendTS/src/models/AccessCode.ts
+++ b/frontendTS/src/models/AccessCode.ts
@@ -1,0 +1,6 @@
+export interface AccessCode {
+  code: string;
+  createdAtUtc: string;
+  expiresAtUtc?: string | null;
+  isValid: boolean;
+}

--- a/frontendTS/src/models/Assignment.ts
+++ b/frontendTS/src/models/Assignment.ts
@@ -1,0 +1,6 @@
+export interface Assignment {
+  id?: number;
+  subjectId: number;
+  videoGroupId: number;
+  projectId?: number;
+}

--- a/frontendTS/src/models/Label.ts
+++ b/frontendTS/src/models/Label.ts
@@ -1,0 +1,8 @@
+export interface Label {
+  id?: number;
+  name: string;
+  colorHex: string;
+  type: string;
+  shortcut: string;
+  subjectId: number;
+}

--- a/frontendTS/src/models/Project.ts
+++ b/frontendTS/src/models/Project.ts
@@ -1,0 +1,6 @@
+export interface Project {
+  id?: number;
+  name: string;
+  description: string;
+  finished: boolean;
+}

--- a/frontendTS/src/models/Report.ts
+++ b/frontendTS/src/models/Report.ts
@@ -1,0 +1,5 @@
+export interface Report {
+  id: number;
+  name: string;
+  createdAtUtc: string;
+}

--- a/frontendTS/src/models/Subject.ts
+++ b/frontendTS/src/models/Subject.ts
@@ -1,0 +1,6 @@
+export interface Subject {
+  id?: number;
+  name: string;
+  description: string;
+  projectId: number;
+}

--- a/frontendTS/src/models/Video.ts
+++ b/frontendTS/src/models/Video.ts
@@ -1,0 +1,6 @@
+export interface Video {
+  id?: number;
+  title: string;
+  positionInQueue: number;
+  videoGroupId: number;
+}

--- a/frontendTS/src/models/VideoGroup.ts
+++ b/frontendTS/src/models/VideoGroup.ts
@@ -1,0 +1,6 @@
+export interface VideoGroup {
+  id?: number;
+  name: string;
+  description: string;
+  projectId: number;
+}

--- a/frontendTS/src/pages/LabelAdd.tsx
+++ b/frontendTS/src/pages/LabelAdd.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import httpClient from "../httpclient";
 import "./css/ScientistProjects.css";
 import NavigateButton from "../components/NavigateButton";
 import { useNotification } from "../context/NotificationContext";
 import { useTranslation } from 'react-i18next';
+import { createLabel } from "../services/api/labelService";
+import { getSubject } from "../services/api/subjectService";
 
 const LabelAdd = () => {
   const [formData, setFormData] = useState({
@@ -30,9 +31,9 @@ const LabelAdd = () => {
     }
   }, [location.search]);
 
-  const fetchSubjectName = async (id) => {
-    const response = await httpClient.get(`/subject/${id}`);
-    setSubjectName(response.data.name);
+  const fetchSubjectName = async (id: number) => {
+    const subject = await getSubject(id);
+    setSubjectName(subject.name);
   };
 
   const handleChange = (e) => {
@@ -56,14 +57,14 @@ const LabelAdd = () => {
     return true;
   };
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
     if (!validateForm() || !formData.name || !formData.type || !formData.subjectId) {
       return;
     }
     
-    await httpClient.post("/label", formData);
+    await createLabel(formData);
     navigate(`/subjects/${formData.subjectId}`);
   };
 

--- a/frontendTS/src/pages/LabelEdit.tsx
+++ b/frontendTS/src/pages/LabelEdit.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import httpClient from "../httpclient";
 import NavigateButton from "../components/NavigateButton";
 import { useTranslation } from 'react-i18next';
 import { useNotification } from "../context/NotificationContext";
+import { getLabel, updateLabel } from "../services/api/labelService";
+import { getSubject } from "../services/api/subjectService";
 
 const LabelEdit = () => {
   const { id } = useParams();
@@ -21,14 +22,15 @@ const LabelEdit = () => {
 
   useEffect(() => {
     const fetchLabelData = async () => {
-      const response = await httpClient.get(`/Label/${id}`);
-      setLabelData(response.data);
-      fetchSubjectName(response.data.subjectId);
+      if (!id) return;
+      const data = await getLabel(parseInt(id));
+      setLabelData(data);
+      fetchSubjectName(data.subjectId);
     };
 
-    const fetchSubjectName = async (subjectId) => {
-      const response = await httpClient.get(`/subject/${subjectId}`);
-      setSubjectName(response.data.name);
+    const fetchSubjectName = async (subjectId: number) => {
+      const subject = await getSubject(subjectId);
+      setSubjectName(subject.name);
     };
 
     if (id) fetchLabelData();
@@ -55,11 +57,11 @@ const LabelEdit = () => {
     return true;
   };
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!validateForm()) return;
-    
-    await httpClient.put(`/Label/${id}`, labelData);
+    if (!id) return;
+    await updateLabel(parseInt(id), labelData);
     navigate(`/subjects/${labelData.subjectId}`);
   };
 

--- a/frontendTS/src/pages/LabelerVideoGroups.tsx
+++ b/frontendTS/src/pages/LabelerVideoGroups.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import httpClient from "../httpclient";
+import { getProjects, joinProject } from "../services/api/projectService";
+import { getAssignments } from "../services/api/assignmentService";
 import "./css/ScientistProjects.css";
 import NavigateButton from "../components/NavigateButton";
 import DataTable from "../components/DataTable";
@@ -30,9 +31,7 @@ const LabelerVideoGroups = () => {
     }
 
     try {
-      await httpClient.post("/project/join", {
-          AccessCode: accessCode.trim(),
-      });
+      await joinProject(accessCode.trim());
       addNotification(t('labeler:join_project.success'), "success");
       setAccessCode("");
       fetchProjects();
@@ -47,10 +46,10 @@ const LabelerVideoGroups = () => {
   const fetchProjects = async () => {
     setLoading(true);
     try {
-      const response = await httpClient.get("/project");
-      setProjects(response.data);
+      const response = await getProjects();
+      setProjects(response);
       const expanded = {};
-      response.data.forEach((project) => {
+      response.forEach((project) => {
         expanded[project.id] = false;
       });
       setExpandedProjects(expanded);
@@ -66,8 +65,8 @@ const LabelerVideoGroups = () => {
 
   const fetchAssignments = async () => {
     try {
-      const response = await httpClient.get(`/SubjectVideoGroupAssignment`);
-      setAssignments(response.data);
+      const response = await getAssignments();
+      setAssignments(response);
     } catch (error) {
       addNotification(
           error.response?.data?.message || t('labeler:errors.load_assignments'),

--- a/frontendTS/src/pages/ProjectAdd.tsx
+++ b/frontendTS/src/pages/ProjectAdd.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import httpClient from "../httpclient";
 import "./css/ScientistProjects.css";
 import NavigateButton from "../components/NavigateButton";
 import { useTranslation } from 'react-i18next';
+import { createProject } from "../services/api/projectService";
 
 function ProjectAdd() {
   const navigate = useNavigate();
@@ -14,9 +14,9 @@ function ProjectAdd() {
   });
   const { t } = useTranslation(['projects', 'common']);
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await httpClient.post("/Project", formData);
+    await createProject(formData);
     navigate("/projects");
   };
 

--- a/frontendTS/src/pages/ProjectDetails.tsx
+++ b/frontendTS/src/pages/ProjectDetails.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useParams, useLocation } from "react-router-dom";
-import httpClient from "../httpclient";
+import { getProject, getProjectReports } from "../services/api/projectService";
 import "./css/ScientistProjects.css";
 import { getSignalRService } from "../services/SignalRServiceInstance";
 import { useNotification } from "../context/NotificationContext";
@@ -36,13 +36,15 @@ const ProjectDetails = () => {
   }, [id]);
 
   const fetchReports = async () => {
-    const response = await httpClient.get(`/project/${id}/reports`);
-    setReports(response.data);
+    if (!id) return;
+    const data = await getProjectReports(parseInt(id));
+    setReports(data);
   };
 
   const fetchBasicProjectData = async () => {
-    const projectRes = await httpClient.get(`/project/${id}`);
-    setProject(projectRes.data);
+    if (!id) return;
+    const projectRes = await getProject(parseInt(id));
+    setProject(projectRes);
     await fetchReports();
   };
 

--- a/frontendTS/src/pages/ProjectEdit.tsx
+++ b/frontendTS/src/pages/ProjectEdit.tsx
@@ -1,13 +1,15 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import httpClient from "../httpclient";
 import "./css/ScientistProjects.css";
 import NavigateButton from "../components/NavigateButton";
 import { useTranslation } from 'react-i18next';
+import useProject from "../hooks/useProject";
+import { updateProject } from "../services/api/projectService";
 
 function ProjectEdit() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const { project } = useProject(id ? parseInt(id) : undefined);
   const [formData, setFormData] = useState({
     name: "",
     description: "",
@@ -15,22 +17,20 @@ function ProjectEdit() {
   });
   const { t } = useTranslation(['projects', 'common']);
 
-  useEffect(() => {
-    const fetchProject = async () => {
-      const response = await httpClient.get(`/Project/${id}`);
-      const data = response.data;
+  React.useEffect(() => {
+    if (project) {
       setFormData({
-        name: data.name,
-        description: data.description,
-        finished: data.finished,
+        name: project.name,
+        description: project.description,
+        finished: project.finished,
       });
-    };
-    fetchProject();
-  }, [id]);
+    }
+  }, [project]);
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await httpClient.put(`/Project/${id}`, formData);
+    if (!id) return;
+    await updateProject(parseInt(id), formData);
     navigate(`/projects/${id}`);
   };
 

--- a/frontendTS/src/pages/Projects.tsx
+++ b/frontendTS/src/pages/Projects.tsx
@@ -1,29 +1,20 @@
-import React, { useState, useEffect } from "react";
-import httpClient from "../httpclient";
+import React from "react";
 import DeleteButton from "../components/DeleteButton";
 import DataTable from "../components/DataTable";
 import "./css/ScientistProjects.css";
 import NavigateButton from "../components/NavigateButton";
 import { useTranslation } from 'react-i18next';
+import useProjects from "../hooks/useProjects";
+import { deleteProject } from "../services/api/projectService";
 
 const Projects = () => {
-  const [projects, setProjects] = useState([]);
+  const { projects, setProjects } = useProjects();
   const { t } = useTranslation(['projects', 'common']);
 
-  const fetchProjects = async () => {
-    const response = await httpClient.get("/Project");
-    setProjects(response.data.sort((a, b) => a.id - b.id));
-  };
-
-  const handleDeleteProject = async (projectId) => {
-    await httpClient.delete(`/Project/${projectId}`);
+  const handleDeleteProject = async (projectId: number) => {
+    await deleteProject(projectId);
     setProjects(prev => prev.filter(project => project.id !== projectId));
   };
-
-  useEffect(() => {
-    
-    fetchProjects();
-  }, []);
 
   const columns = [
     { field: "name", header: t('projects:form.name') },

--- a/frontendTS/src/pages/SubjectAdd.tsx
+++ b/frontendTS/src/pages/SubjectAdd.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import httpClient from "../httpclient";
 import "./css/ScientistProjects.css";
 import NavigateButton from "../components/NavigateButton";
 import { useTranslation } from 'react-i18next';
+import { createSubject } from "../services/api/subjectService";
 
 const AddSubject = () => {
     const location = useLocation();
@@ -21,9 +21,9 @@ const AddSubject = () => {
         setSubjectData((prev) => ({ ...prev, [name]: value }));
     };
 
-    const handleSubmit = async (e) => {
+    const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        await httpClient.post("/Subject", subjectData);
+        await createSubject(subjectData);
         navigate(`/projects/${projectId}`);
     };
 

--- a/frontendTS/src/pages/SubjectVideoGroupAssignmentAdd.tsx
+++ b/frontendTS/src/pages/SubjectVideoGroupAssignmentAdd.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import httpClient from "../httpclient";
 import "./css/ScientistProjects.css";
 import NavigateButton from "../components/NavigateButton";
 import { useTranslation } from 'react-i18next';
+import { getProjectSubjects, getProjectVideoGroups } from "../services/api/projectService";
+import { createAssignment } from "../services/api/assignmentService";
 
 const SubjectVideoGroupAssignmentAdd = () => {
   const { t } = useTranslation(['assignments', 'common']);
@@ -26,14 +27,14 @@ const SubjectVideoGroupAssignmentAdd = () => {
     }
   }, [location.search]);
 
-  const fetchSubjectsAndVideoGroups = async (projectId) => {
-    const [subjectsRes, videoGroupsRes] = await Promise.all([
-      httpClient.get(`/project/${projectId}/subjects`),
-      httpClient.get(`/project/${projectId}/videogroups`),
+  const fetchSubjectsAndVideoGroups = async (projectId: number) => {
+    const [subjectsData, videoGroupsData] = await Promise.all([
+      getProjectSubjects(projectId),
+      getProjectVideoGroups(projectId),
     ]);
 
-    setSubjects(subjectsRes.data);
-    setVideoGroups(videoGroupsRes.data);
+    setSubjects(subjectsData);
+    setVideoGroups(videoGroupsData);
   };
 
   const handleChange = (e) => {
@@ -48,7 +49,7 @@ const SubjectVideoGroupAssignmentAdd = () => {
       return;
     }
 
-    await httpClient.post("/SubjectVideoGroupAssignment", {
+    await createAssignment({
       subjectId: parseInt(formData.subjectId),
       videoGroupId: parseInt(formData.videoGroupId),
     });

--- a/frontendTS/src/pages/SubjectVideoGroupAssignmentDetails.tsx
+++ b/frontendTS/src/pages/SubjectVideoGroupAssignmentDetails.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import httpClient from "../httpclient";
 import "./css/ScientistProjects.css";
 import DeleteButton from "../components/DeleteButton";
 import DataTable from "../components/DataTable";
 import NavigateButton from "../components/NavigateButton";
 import { useTranslation } from 'react-i18next';
+import { getAssignment, deleteAssignment, getAssignmentLabelers } from "../services/api/assignmentService";
+import { getSubject } from "../services/api/subjectService";
+import { getVideoGroup } from "../services/api/videoGroupService";
 
 const SubjectVideoGroupAssignmentDetails = () => {
   const { t } = useTranslation(['assignments', 'common']);
@@ -21,19 +23,19 @@ const SubjectVideoGroupAssignmentDetails = () => {
   ];
 
   const fetchData = async () => {
-    const assignmentResponse = await httpClient.get(`/SubjectVideoGroupAssignment/${id}`);
-    setAssignmentDetails(assignmentResponse.data);
+    if (!id) return;
+    const assignment = await getAssignment(parseInt(id));
+    setAssignmentDetails(assignment);
 
-    const [subjectResponse, videoGroupResponse] = await Promise.all([
-      httpClient.get(`/subject/${assignmentResponse.data.subjectId}`),
-      httpClient.get(`/videogroup/${assignmentResponse.data.videoGroupId}`),
+    const [subjectData, videoGroupData, labelersData] = await Promise.all([
+      getSubject(assignment.subjectId),
+      getVideoGroup(assignment.videoGroupId),
+      getAssignmentLabelers(parseInt(id)),
     ]);
 
-    setSubject(subjectResponse.data);
-    setVideoGroup(videoGroupResponse.data);
-
-    const labelersResponse = await httpClient.get(`/SubjectVideoGroupAssignment/${id}/labelers`);
-    setLabelers(labelersResponse.data);
+    setSubject(subjectData);
+    setVideoGroup(videoGroupData);
+    setLabelers(labelersData);
   };
 
   useEffect(() => {
@@ -42,7 +44,8 @@ const SubjectVideoGroupAssignmentDetails = () => {
 
   const handleDelete = async () => {
     if (!window.confirm(t('assignments:confirm.delete'))) return;
-    await httpClient.delete(`/SubjectVideoGroupAssignment/${id}`);
+    if (!id) return;
+    await deleteAssignment(parseInt(id));
     navigate(-1);
   };
 

--- a/frontendTS/src/pages/VideoDetails.tsx
+++ b/frontendTS/src/pages/VideoDetails.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
-import httpClient from "../httpclient";
 import "./css/ScientistProjects.css";
 import DataTable from "../components/DataTable";
 import NavigateButton from "../components/NavigateButton";
 import { useTranslation } from "react-i18next";
+import { getVideo, getVideoStream, getAssignedLabels } from "../services/api/videoService";
 
 const VideoDetails = () => {
     const { id: videoId } = useParams();
@@ -20,22 +20,23 @@ const VideoDetails = () => {
         fetchAssignedLabels(videoId);
     }, [videoId]);
 
-    const fetchVideoDetails = async (videoId) => {
-        const response = await httpClient.get(`/Video/${videoId}`);
-        setVideoData(response.data);
+    const fetchVideoDetails = async (videoId: string | undefined) => {
+        if (!videoId) return;
+        const data = await getVideo(parseInt(videoId));
+        setVideoData(data);
     };
 
     async function fetchVideoStream(videoId) {
-        const response = await httpClient.get(`/Video/${videoId}/stream`, {
-            responseType: "blob",
-        });
-        const streamUrl = URL.createObjectURL(response.data);
+        if (!videoId) return;
+        const blob = await getVideoStream(parseInt(videoId));
+        const streamUrl = URL.createObjectURL(blob);
         setVideoStream(streamUrl);
     }
 
-    const fetchAssignedLabels = async (videoId) => {
-        const response = await httpClient.get(`/Video/${videoId}/assignedlabels`);
-        setLabels(response.data);
+    const fetchAssignedLabels = async (videoId: string | undefined) => {
+        if (!videoId) return;
+        const data = await getAssignedLabels(parseInt(videoId));
+        setLabels(data);
     };
 
     const labelColumns = [

--- a/frontendTS/src/pages/VideoGroupAdd.tsx
+++ b/frontendTS/src/pages/VideoGroupAdd.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import httpClient from "../httpclient";
 import "./css/ScientistProjects.css";
 import NavigateButton from "../components/NavigateButton";
 import { useTranslation } from "react-i18next";
+import { createVideoGroup } from "../services/api/videoGroupService";
 
 const VideoGroupAdd = () => {
   const [formData, setFormData] = useState({
@@ -28,9 +28,9 @@ const VideoGroupAdd = () => {
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await httpClient.post("/videogroup", formData);
+    await createVideoGroup(formData);
     navigate(`/projects/${formData.projectId}`);
   };
 

--- a/frontendTS/src/pages/VideoGroupsDetails.tsx
+++ b/frontendTS/src/pages/VideoGroupsDetails.tsx
@@ -1,11 +1,13 @@
 ﻿import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
-import httpClient, { API_BASE_URL } from "../httpclient";
+import { API_BASE_URL } from "../httpclient";
 import DeleteButton from "../components/DeleteButton";
 import "./css/ScientistProjects.css";
 import NavigateButton from "../components/NavigateButton";
 import DataTable from "../components/DataTable";
 import { useTranslation } from "react-i18next";
+import { getVideoGroup, getVideoGroupVideos } from "../services/api/videoGroupService";
+import { deleteVideo } from "../services/api/videoService";
 
 const VideoGroupDetails = () => {
   const { id } = useParams();
@@ -14,22 +16,24 @@ const VideoGroupDetails = () => {
   const { t } = useTranslation(['videos', 'common']);
 
   async function fetchVideoGroupDetails() {
-    const response = await httpClient.get(`/videogroup/${id}`);
-    setVideoGroupDetails(response.data);
+    if (!id) return;
+    const data = await getVideoGroup(parseInt(id));
+    setVideoGroupDetails(data);
     fetchVideos();
   }
 
   async function fetchVideos() {
-    const response = await httpClient.get(`/VideoGroup/${id}/videos`);
-    setVideos(response.data);
+    if (!id) return;
+    const data = await getVideoGroupVideos(parseInt(id));
+    setVideos(data);
   }
 
   useEffect(() => {
     if (id) fetchVideoGroupDetails();
   }, [id]);
 
-  const handleDeleteVideo = async (videoId) => {
-    await httpClient.delete(`/video/${videoId}`);
+  const handleDeleteVideo = async (videoId: number) => {
+    await deleteVideo(videoId);
     setVideos(videos.filter((video) => video.id !== videoId));
   };
 

--- a/frontendTS/src/pages/Videos/Index.tsx
+++ b/frontendTS/src/pages/Videos/Index.tsx
@@ -7,7 +7,7 @@ import VideoPlayers from "./components/VideoPlayers";
 import ProgressBar from "./components/ProgressBar";
 import BatchNavigation from "./components/BatchNavigation";
 import LabelInterface from "./components/LabelInterface";
-import httpClient from "../../httpclient";
+import { getAssignment } from "../../services/api/assignmentService";
 
 const Videos = () => {
     const { id: assignmentId } = useParams();
@@ -39,12 +39,10 @@ const Videos = () => {
     useEffect(() => {
         const fetchAssignment = async () => {
             try {
-                const response = await httpClient.get(
-                    `/SubjectVideoGroupAssignment/${assignmentId}`
-                );
+                const data = await getAssignment(parseInt(assignmentId));
                 setAssignment({
-                    subjectId: response.data.subjectId,
-                    videoGroupId: response.data.videoGroupId,
+                    subjectId: data.subjectId,
+                    videoGroupId: data.videoGroupId,
                 });
             } catch (error) {
                 console.error(error);

--- a/frontendTS/src/pages/Videos/hooks/useVideoGroup.tsx
+++ b/frontendTS/src/pages/Videos/hooks/useVideoGroup.tsx
@@ -1,5 +1,6 @@
-﻿import { useState, useEffect, useCallback } from "react";
-import httpClient from "../../../httpclient";
+import { useState, useEffect, useCallback } from "react";
+import { getVideoGroup, getVideoBatch } from "../../../services/api/videoGroupService";
+import { getVideoStream } from "../../../services/api/videoService";
 
 const useVideoGroup = (videoGroupId) => {
     const [videoGroup, setVideoGroup] = useState({
@@ -17,12 +18,9 @@ const useVideoGroup = (videoGroupId) => {
         const streams = await Promise.all(
             videoIds.map(async (videoId) => {
                 try {
-                    const response = await httpClient.get(`/Video/${videoId}/stream`, {
-                        responseType: "blob",
-                        skipLoadingScreen: true,
-                    });
-                    return URL.createObjectURL(response.data);
-                } catch (error) {
+                    const blob = await getVideoStream(videoId);
+                    return URL.createObjectURL(blob);
+                } catch {
                     return null;
                 }
             })
@@ -36,15 +34,15 @@ const useVideoGroup = (videoGroupId) => {
 
             try {
                 const [groupRes, videosRes] = await Promise.all([
-                    httpClient.get(`/VideoGroup/${videoGroupId}`),
-                    httpClient.get(`/Video/batch/${videoGroupId}/${batch}`),
+                    getVideoGroup(videoGroupId),
+                    getVideoBatch(videoGroupId, batch),
                 ]);
 
-                const streams = await fetchVideoStreams(videosRes.data);
+                const streams = await fetchVideoStreams(videosRes);
 
                 setVideoGroup({
-                    positions: groupRes.data.videosAtPositions,
-                    videos: videosRes.data,
+                    positions: groupRes.videosAtPositions,
+                    videos: videosRes,
                     streams,
                 });
                 setBatchState((prev) => ({ ...prev, currentBatch: batch }));

--- a/frontendTS/src/services/api/assignedLabelService.ts
+++ b/frontendTS/src/services/api/assignedLabelService.ts
@@ -1,0 +1,14 @@
+import httpClient from '../../httpclient';
+
+export const createAssignedLabel = async (
+  labelId: number,
+  videoId: number,
+  start: string,
+  end: string,
+): Promise<void> => {
+  await httpClient.post('/AssignedLabel', { labelId, videoId, start, end });
+};
+
+export const deleteAssignedLabel = async (id: number): Promise<void> => {
+  await httpClient.delete(`/AssignedLabel/${id}`);
+};

--- a/frontendTS/src/services/api/assignmentService.ts
+++ b/frontendTS/src/services/api/assignmentService.ts
@@ -1,0 +1,25 @@
+import httpClient from '../../httpclient';
+import { Assignment } from '../../models/Assignment';
+
+export const createAssignment = async (assignment: Omit<Assignment, 'id'>): Promise<void> => {
+  await httpClient.post('/SubjectVideoGroupAssignment', assignment);
+};
+
+export const getAssignment = async (id: number): Promise<Assignment> => {
+  const { data } = await httpClient.get<Assignment>(`/SubjectVideoGroupAssignment/${id}`);
+  return data;
+};
+
+export const deleteAssignment = async (id: number): Promise<void> => {
+  await httpClient.delete(`/SubjectVideoGroupAssignment/${id}`);
+};
+
+export const getAssignmentLabelers = async (id: number) => {
+  const { data } = await httpClient.get(`/SubjectVideoGroupAssignment/${id}/labelers`);
+  return data;
+};
+
+export const getAssignments = async (): Promise<Assignment[]> => {
+  const { data } = await httpClient.get<Assignment[]>('/SubjectVideoGroupAssignment');
+  return data;
+};

--- a/frontendTS/src/services/api/labelService.ts
+++ b/frontendTS/src/services/api/labelService.ts
@@ -1,0 +1,19 @@
+import httpClient from '../../httpclient';
+import { Label } from '../../models/Label';
+
+export const getLabel = async (id: number): Promise<Label> => {
+  const { data } = await httpClient.get<Label>(`/Label/${id}`);
+  return data;
+};
+
+export const createLabel = async (label: Omit<Label, 'id'>): Promise<void> => {
+  await httpClient.post('/label', label);
+};
+
+export const updateLabel = async (id: number, label: Omit<Label, 'id'>): Promise<void> => {
+  await httpClient.put(`/Label/${id}`, label);
+};
+
+export const deleteLabel = async (id: number): Promise<void> => {
+  await httpClient.delete(`/label/${id}`);
+};

--- a/frontendTS/src/services/api/projectService.ts
+++ b/frontendTS/src/services/api/projectService.ts
@@ -1,0 +1,56 @@
+import httpClient from '../../httpclient';
+import { Project } from '../../models/Project';
+
+export const getProjects = async (): Promise<Project[]> => {
+  const { data } = await httpClient.get<Project[]>('/Project');
+  return data;
+};
+
+export const getProject = async (id: number): Promise<Project> => {
+  const { data } = await httpClient.get<Project>(`/Project/${id}`);
+  return data;
+};
+
+export const createProject = async (project: Omit<Project, 'id'>): Promise<void> => {
+  await httpClient.post('/Project', project);
+};
+
+export const updateProject = async (id: number, project: Omit<Project, 'id'>): Promise<void> => {
+  await httpClient.put(`/Project/${id}`, project);
+};
+
+export const deleteProject = async (id: number): Promise<void> => {
+  await httpClient.delete(`/Project/${id}`);
+};
+
+export const getProjectSubjects = async (projectId: number) => {
+  const { data } = await httpClient.get(`/project/${projectId}/subjects`);
+  return data;
+};
+
+export const getProjectVideoGroups = async (projectId: number) => {
+  const { data } = await httpClient.get(`/project/${projectId}/videogroups`);
+  return data;
+};
+
+export const joinProject = async (accessCode: string): Promise<void> => {
+  await httpClient.post('/project/join', { AccessCode: accessCode });
+};
+
+export const getProjectReports = async (projectId: number) => {
+  const { data } = await httpClient.get(`/project/${projectId}/reports`);
+  return data;
+};
+
+export const generateProjectReport = async (projectId: number): Promise<void> => {
+  await httpClient.post(`/projectreport/${projectId}/generate-report`);
+};
+
+export const deleteProjectReport = async (reportId: number): Promise<void> => {
+  await httpClient.delete(`/projectreport/${reportId}`);
+};
+
+export const downloadProjectReport = async (reportId: number): Promise<Blob> => {
+  const { data } = await httpClient.get(`/projectreport/download/${reportId}`, { responseType: 'blob' });
+  return data;
+};

--- a/frontendTS/src/services/api/subjectService.ts
+++ b/frontendTS/src/services/api/subjectService.ts
@@ -1,0 +1,17 @@
+import httpClient from '../../httpclient';
+import { Subject } from '../../models/Subject';
+import { Label } from '../../models/Label';
+
+export const getSubject = async (id: number): Promise<Subject> => {
+  const { data } = await httpClient.get<Subject>(`/subject/${id}`);
+  return data;
+};
+
+export const createSubject = async (subject: Omit<Subject, 'id'>): Promise<void> => {
+  await httpClient.post('/Subject', subject);
+};
+
+export const getSubjectLabels = async (id: number): Promise<Label[]> => {
+  const { data } = await httpClient.get<Label[]>(`/subject/${id}/label`);
+  return data;
+};

--- a/frontendTS/src/services/api/videoGroupService.ts
+++ b/frontendTS/src/services/api/videoGroupService.ts
@@ -1,0 +1,22 @@
+import httpClient from '../../httpclient';
+import { VideoGroup } from '../../models/VideoGroup';
+import { Video } from '../../models/Video';
+
+export const getVideoGroup = async (id: number): Promise<VideoGroup> => {
+  const { data } = await httpClient.get<VideoGroup>(`/videogroup/${id}`);
+  return data;
+};
+
+export const createVideoGroup = async (group: Omit<VideoGroup, 'id'>): Promise<void> => {
+  await httpClient.post('/videogroup', group);
+};
+
+export const getVideoGroupVideos = async (id: number): Promise<Video[]> => {
+  const { data } = await httpClient.get<Video[]>(`/VideoGroup/${id}/videos`);
+  return data;
+};
+
+export const getVideoBatch = async (videoGroupId: number, batch: number) => {
+  const { data } = await httpClient.get(`/Video/batch/${videoGroupId}/${batch}`);
+  return data;
+};

--- a/frontendTS/src/services/api/videoService.ts
+++ b/frontendTS/src/services/api/videoService.ts
@@ -1,0 +1,27 @@
+import httpClient from '../../httpclient';
+import { Video } from '../../models/Video';
+
+export const createVideo = async (
+  formData: FormData,
+  onUploadProgress?: (event: ProgressEvent) => void,
+): Promise<void> => {
+  await httpClient.post('/video', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+    onUploadProgress,
+  });
+};
+
+export const getVideo = async (id: number): Promise<Video> => {
+  const { data } = await httpClient.get<Video>(`/Video/${id}`);
+  return data;
+};
+
+export const getVideoStream = async (id: number): Promise<Blob> => {
+  const { data } = await httpClient.get(`/Video/${id}/stream`, { responseType: 'blob' });
+  return data;
+};
+
+export const getAssignedLabels = async (id: number) => {
+  const { data } = await httpClient.get(`/Video/${id}/assignedlabels`);
+  return data;
+};


### PR DESCRIPTION
## Summary
- add models for access codes and reports
- create an assigned label API service
- replace direct httpClient calls with API services in remaining pages and hooks
- update video and label management pages to use the new services

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*