### PR TITLE
Refactor pages to use custom hooks

### DIFF
--- a/frontendTS/src/hooks/useAssignmentAdd.ts
+++ b/frontendTS/src/hooks/useAssignmentAdd.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { getProjectSubjects, getProjectVideoGroups } from '../services/api/projectService';
+import { createAssignment } from '../services/api/assignmentService';
+import { Subject } from '../models/Subject';
+import { VideoGroup } from '../models/VideoGroup';
+
+interface AssignmentForm {
+  subjectId: string;
+  videoGroupId: string;
+}
+
+export default function useAssignmentAdd(search: string) {
+  const navigate = useNavigate();
+  const { t } = useTranslation(['assignments', 'common']);
+  const [formData, setFormData] = useState<AssignmentForm>({ subjectId: '', videoGroupId: '' });
+  const [subjects, setSubjects] = useState<Subject[]>([]);
+  const [videoGroups, setVideoGroups] = useState<VideoGroup[]>([]);
+  const [projectId, setProjectId] = useState<number | null>(null);
+
+  const fetchData = useCallback(async (id: number) => {
+    const [subjectsData, videoGroupsData] = await Promise.all([
+      getProjectSubjects(id),
+      getProjectVideoGroups(id),
+    ]);
+    setSubjects(subjectsData);
+    setVideoGroups(videoGroupsData);
+  }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+    const projectIdParam = params.get('projectId');
+    if (projectIdParam) {
+      const pid = parseInt(projectIdParam);
+      setProjectId(pid);
+      fetchData(pid);
+    }
+  }, [search, fetchData]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.subjectId || !formData.videoGroupId) return;
+    await createAssignment({
+      subjectId: parseInt(formData.subjectId),
+      videoGroupId: parseInt(formData.videoGroupId),
+    });
+    navigate(`/projects/${projectId}`);
+  };
+
+  return {
+    formData,
+    subjects,
+    videoGroups,
+    projectId,
+    handleChange,
+    handleSubmit,
+  };
+}

--- a/frontendTS/src/hooks/useAssignmentDetails.ts
+++ b/frontendTS/src/hooks/useAssignmentDetails.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState, useCallback } from 'react';
+import { getAssignment, getAssignmentLabelers, deleteAssignment } from '../services/api/assignmentService';
+import { getSubject } from '../services/api/subjectService';
+import { getVideoGroup } from '../services/api/videoGroupService';
+
+export default function useAssignmentDetails(id?: number) {
+    const [assignment, setAssignment] = useState<any>(null);
+    const [subject, setSubject] = useState<any>(null);
+    const [videoGroup, setVideoGroup] = useState<any>(null);
+    const [labelers, setLabelers] = useState<any[]>([]);
+
+    const fetchData = useCallback(async () => {
+        if (!id) return;
+        const assignmentData = await getAssignment(id);
+        setAssignment(assignmentData);
+        const [subjectData, videoGroupData, labelerData] = await Promise.all([
+            getSubject(assignmentData.subjectId),
+            getVideoGroup(assignmentData.videoGroupId),
+            getAssignmentLabelers(id),
+        ]);
+        setSubject(subjectData);
+        setVideoGroup(videoGroupData);
+        setLabelers(labelerData);
+    }, [id]);
+
+    const handleDelete = async () => {
+        if (!id) return;
+        await deleteAssignment(id);
+    };
+
+    useEffect(() => {
+        fetchData();
+    }, [fetchData]);
+
+    return { assignment, subject, videoGroup, labelers, fetchData, handleDelete };
+}

--- a/frontendTS/src/hooks/useAuthForm.ts
+++ b/frontendTS/src/hooks/useAuthForm.ts
@@ -1,0 +1,107 @@
+import { useState, useEffect, useCallback } from 'react';
+import authService from '../auth';
+import { useAuth } from '../context/AuthContext';
+import { useNotification } from '../context/NotificationContext';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+interface FormData {
+    username: string;
+    email: string;
+    password: string;
+    confirmPassword: string;
+    ScientistCreateToken?: string;
+    role: 'Labeler' | 'Scientist';
+}
+
+export default function useAuthForm() {
+    const [isLoginView, setIsLoginView] = useState(true);
+    const [formData, setFormData] = useState<FormData>({
+        username: '',
+        email: '',
+        password: '',
+        confirmPassword: '',
+        ScientistCreateToken: '',
+        role: 'Labeler',
+    });
+    const [loading, setLoading] = useState(false);
+    const [loginSuccess, setLoginSuccess] = useState(false);
+
+    const navigate = useNavigate();
+    const { t } = useTranslation(['auth']);
+    const { handleLogin, roles, isAuthenticated } = useAuth();
+    const { addNotification } = useNotification();
+
+    const redirectIfAuthenticated = useCallback(() => {
+        if (isAuthenticated) {
+            if (roles.includes('Scientist')) {
+                navigate('/projects');
+            } else if (roles.includes('Labeler')) {
+                navigate('/labeler-video-groups');
+            } else {
+                addNotification(t('auth:error.no_access'), 'error');
+            }
+        }
+    }, [isAuthenticated, roles, navigate, addNotification, t]);
+
+    useEffect(() => {
+        redirectIfAuthenticated();
+    }, [redirectIfAuthenticated]);
+
+    useEffect(() => {
+        if (loginSuccess) {
+            addNotification(t('auth:notification.login_success'), 'success');
+            redirectIfAuthenticated();
+            setLoginSuccess(false);
+        }
+    }, [loginSuccess, redirectIfAuthenticated, addNotification, t]);
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+        setFormData({ ...formData, [e.target.name]: e.target.value });
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setLoading(true);
+
+        if (!isLoginView && formData.password !== formData.confirmPassword) {
+            addNotification(t('auth:error.password_mismatch'), 'error');
+            setLoading(false);
+            return;
+        }
+
+        try {
+            if (isLoginView) {
+                await handleLogin(formData.username, formData.password);
+                setLoginSuccess(true);
+            } else {
+                await authService.register({
+                    userName: formData.username,
+                    email: formData.email,
+                    password: formData.password,
+                    role: formData.role,
+                    scientistCreateToken: formData.role === 'Scientist' ? formData.ScientistCreateToken : undefined,
+                });
+                setIsLoginView(true);
+                setFormData({ ...formData, password: '', confirmPassword: '' });
+                addNotification(t('auth:notification.registration_success'), 'success');
+            }
+        } catch (err: any) {
+            addNotification(
+                err.message || t(isLoginView ? 'auth:error.invalid_credentials' : 'auth:error.registration_failed'),
+                'error'
+            );
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return {
+        isLoginView,
+        formData,
+        loading,
+        setIsLoginView,
+        handleInputChange,
+        handleSubmit,
+    };
+}

--- a/frontendTS/src/hooks/useLabelAdd.ts
+++ b/frontendTS/src/hooks/useLabelAdd.ts
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useNotification } from '../context/NotificationContext';
+import { useTranslation } from 'react-i18next';
+import { createLabel } from '../services/api/labelService';
+import { getSubject } from '../services/api/subjectService';
+
+interface LabelFormData {
+  name: string;
+  colorHex: string;
+  type: string;
+  shortcut: string;
+  subjectId: number | null;
+}
+
+export default function useLabelAdd(search: string) {
+  const [formData, setFormData] = useState<LabelFormData>({
+    name: '',
+    colorHex: '#3498db',
+    type: 'range',
+    shortcut: '',
+    subjectId: null,
+  });
+  const [subjectName, setSubjectName] = useState('');
+  const navigate = useNavigate();
+  const { addNotification } = useNotification();
+  const { t } = useTranslation(['labels', 'common']);
+
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+    const id = params.get('subjectId');
+    if (id) {
+      const num = parseInt(id);
+      setFormData(prev => ({ ...prev, subjectId: num }));
+      fetchSubjectName(num);
+    }
+  }, [search]);
+
+  const fetchSubjectName = async (id: number) => {
+    const subject = await getSubject(id);
+    setSubjectName(subject.name);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const validateForm = () => {
+    if (formData.shortcut.length !== 1) {
+      addNotification(t('labels:notification.validation.shortcut'), 'error');
+      return false;
+    }
+    if (!/^#[0-9A-Fa-f]{6}$/.test(formData.colorHex)) {
+      addNotification(t('labels:notification.validation.color'), 'error');
+      return false;
+    }
+    if (!formData.name) {
+      addNotification(t('labels:notification.validation.name'), 'error');
+      return false;
+    }
+    return true;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validateForm() || !formData.subjectId) return;
+    await createLabel(formData as any);
+    navigate(`/subjects/${formData.subjectId}`);
+  };
+
+  return {
+    formData,
+    subjectName,
+    setFormData,
+    handleChange,
+    handleSubmit,
+  };
+}

--- a/frontendTS/src/hooks/useLabelEdit.ts
+++ b/frontendTS/src/hooks/useLabelEdit.ts
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useNotification } from '../context/NotificationContext';
+import { useTranslation } from 'react-i18next';
+import { getLabel, updateLabel } from '../services/api/labelService';
+import { getSubject } from '../services/api/subjectService';
+
+interface LabelFormData {
+  name: string;
+  colorHex: string;
+  type: string;
+  shortcut: string;
+  subjectId: number | null;
+}
+
+export default function useLabelEdit(id?: number) {
+  const [formData, setFormData] = useState<LabelFormData>({
+    name: '',
+    colorHex: '#ffffff',
+    type: 'range',
+    shortcut: '',
+    subjectId: null,
+  });
+  const [subjectName, setSubjectName] = useState('');
+  const navigate = useNavigate();
+  const { addNotification } = useNotification();
+  const { t } = useTranslation(['labels', 'common']);
+
+  useEffect(() => {
+    const fetchLabelData = async () => {
+      if (!id) return;
+      const data = await getLabel(id);
+      setFormData({ ...data });
+      fetchSubjectName(data.subjectId);
+    };
+    if (id) fetchLabelData();
+  }, [id]);
+
+  const fetchSubjectName = async (subjectId: number) => {
+    const subject = await getSubject(subjectId);
+    setSubjectName(subject.name);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const validateForm = () => {
+    if (formData.shortcut.length !== 1) {
+      addNotification(t('labels:notification.validation.shortcut'), 'error');
+      return false;
+    }
+    if (!/^#[0-9A-Fa-f]{6}$/.test(formData.colorHex)) {
+      addNotification(t('labels:notification.validation.color'), 'error');
+      return false;
+    }
+    if (!formData.name) {
+      addNotification(t('labels:notification.validation.name'), 'error');
+      return false;
+    }
+    return true;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validateForm() || !id) return;
+    await updateLabel(id, formData as any);
+    navigate(`/subjects/${formData.subjectId}`);
+  };
+
+  return { formData, subjectName, setFormData, handleChange, handleSubmit };
+}

--- a/frontendTS/src/hooks/useLabelerVideoGroups.ts
+++ b/frontendTS/src/hooks/useLabelerVideoGroups.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Project } from '../models/Project';
+import { Assignment } from '../models/Assignment';
+import { getProjects, joinProject } from '../services/api/projectService';
+import { getAssignments } from '../services/api/assignmentService';
+import { useNotification } from '../context/NotificationContext';
+import { useTranslation } from 'react-i18next';
+
+export default function useLabelerVideoGroups() {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [assignments, setAssignments] = useState<Assignment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [accessCode, setAccessCode] = useState('');
+  const [expandedProjects, setExpandedProjects] = useState<Record<number, boolean>>({});
+  const { addNotification } = useNotification();
+  const { t } = useTranslation(['labeler', 'common']);
+
+  const fetchAssignments = useCallback(async () => {
+    try {
+      const data = await getAssignments();
+      setAssignments(data);
+    } catch (error: any) {
+      addNotification(error.response?.data?.message || t('labeler:errors.load_assignments'), 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [addNotification, t]);
+
+  const fetchProjects = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await getProjects();
+      setProjects(data);
+      const expanded: Record<number, boolean> = {};
+      data.forEach(p => { expanded[p.id!] = false; });
+      setExpandedProjects(expanded);
+      await fetchAssignments();
+    } catch (error: any) {
+      addNotification(error.response?.data?.message || t('labeler:errors.load_projects'), 'error');
+      setLoading(false);
+    }
+  }, [addNotification, t, fetchAssignments]);
+
+  useEffect(() => {
+    fetchProjects();
+  }, [fetchProjects]);
+
+  const handleJoinProject = async () => {
+    if (!accessCode.trim()) {
+      addNotification(t('labeler:join_project.required_code'), 'error');
+      return;
+    }
+    try {
+      await joinProject(accessCode.trim());
+      addNotification(t('labeler:join_project.success'), 'success');
+      setAccessCode('');
+      fetchProjects();
+    } catch (error: any) {
+      addNotification(error.response?.data?.message || t('labeler:join_project.invalid_code'), 'error');
+    }
+  };
+
+  const toggleProjectExpand = (projectId: number) => {
+    setExpandedProjects(prev => ({ ...prev, [projectId]: !prev[projectId] }));
+  };
+
+  const getProjectAssignments = (projectId: number) => {
+    return assignments.filter(a => a.projectId === projectId);
+  };
+
+  return {
+    projects,
+    assignments,
+    loading,
+    accessCode,
+    setAccessCode,
+    expandedProjects,
+    toggleProjectExpand,
+    getProjectAssignments,
+    handleJoinProject,
+  };
+}

--- a/frontendTS/src/hooks/useProjectDetails.ts
+++ b/frontendTS/src/hooks/useProjectDetails.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Project } from '../models/Project';
+import { Report } from '../models/Report';
+import { getProject, getProjectReports } from '../services/api/projectService';
+import { getSignalRService } from '../services/SignalRServiceInstance';
+import { useNotification } from '../context/NotificationContext';
+import { MessageTypes } from '../config/messageTypes';
+
+export default function useProjectDetails(id?: number) {
+  const [project, setProject] = useState<Project | null>(null);
+  const [reports, setReports] = useState<Report[]>([]);
+  const [activeTab, setActiveTab] = useState('details');
+  const [labelersCount, setLabelersCount] = useState(0);
+  const { addNotification } = useNotification();
+
+  const fetchReports = useCallback(async () => {
+    if (!id) return;
+    const data = await getProjectReports(id);
+    setReports(data);
+  }, [id]);
+
+  const fetchProject = useCallback(async () => {
+    if (!id) return;
+    const data = await getProject(id);
+    setProject(data);
+    await fetchReports();
+  }, [id, fetchReports]);
+
+  useEffect(() => {
+    fetchProject();
+  }, [fetchProject]);
+
+  useEffect(() => {
+    const cached = localStorage.getItem(`project_${id}_activeTab`);
+    if (cached) setActiveTab(cached);
+  }, [id]);
+
+  useEffect(() => {
+    const signalRService = getSignalRService(addNotification);
+    signalRService.onMessage(MessageTypes.LabelersCountChanged, (msg: number) => setLabelersCount(msg));
+    signalRService.onMessage(MessageTypes.ReportGenerated, fetchReports);
+  }, [addNotification, fetchReports]);
+
+  const handleTabChange = (tab: string) => {
+    setActiveTab(tab);
+    if (id) localStorage.setItem(`project_${id}_activeTab`, tab);
+  };
+
+  return { project, reports, activeTab, handleTabChange, labelersCount, setLabelersCount, fetchReports };
+}

--- a/frontendTS/src/hooks/useSubjectLabels.ts
+++ b/frontendTS/src/hooks/useSubjectLabels.ts
@@ -1,0 +1,19 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Label } from '../models/Label';
+import { getSubjectLabels } from '../services/api/subjectService';
+
+export default function useSubjectLabels(id?: number) {
+  const [labels, setLabels] = useState<Label[]>([]);
+
+  const fetchLabels = useCallback(async () => {
+    if (!id) return;
+    const data = await getSubjectLabels(id);
+    setLabels(data.filter(l => l.subjectId === id).sort((a, b) => (a.id || 0) - (b.id || 0)));
+  }, [id]);
+
+  useEffect(() => {
+    fetchLabels();
+  }, [fetchLabels]);
+
+  return { labels, fetchLabels };
+}

--- a/frontendTS/src/hooks/useVideoDetails.ts
+++ b/frontendTS/src/hooks/useVideoDetails.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { Video } from '../models/Video';
+import { AssignedLabel } from '../models/AssignedLabel';
+import { getVideo, getVideoStream, getAssignedLabels } from '../services/api/videoService';
+
+interface VideoDetailsState {
+    video?: Video;
+    stream?: string;
+    labels: AssignedLabel[];
+    loading: boolean;
+}
+
+export default function useVideoDetails(id?: number) {
+    const [state, setState] = useState<VideoDetailsState>({ labels: [], loading: true });
+
+    useEffect(() => {
+        if (!id) return;
+        const fetch = async () => {
+            try {
+                const [video, streamBlob, labels] = await Promise.all([
+                    getVideo(id),
+                    getVideoStream(id),
+                    getAssignedLabels(id),
+                ]);
+                setState({
+                    video,
+                    stream: URL.createObjectURL(streamBlob),
+                    labels,
+                    loading: false,
+                });
+            } catch {
+                setState(prev => ({ ...prev, loading: false }));
+            }
+        };
+        fetch();
+    }, [id]);
+
+    return state;
+}

--- a/frontendTS/src/hooks/useVideoGroupDetails.ts
+++ b/frontendTS/src/hooks/useVideoGroupDetails.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useState } from 'react';
+import { VideoGroup } from '../models/VideoGroup';
+import { Video } from '../models/Video';
+import { getVideoGroup, getVideoGroupVideos } from '../services/api/videoGroupService';
+
+export default function useVideoGroupDetails(id?: number) {
+  const [videoGroup, setVideoGroup] = useState<VideoGroup | null>(null);
+  const [videos, setVideos] = useState<Video[]>([]);
+
+  const fetchVideos = useCallback(async () => {
+    if (!id) return;
+    const data = await getVideoGroupVideos(id);
+    setVideos(data);
+  }, [id]);
+
+  const fetchVideoGroup = useCallback(async () => {
+    if (!id) return;
+    const data = await getVideoGroup(id);
+    setVideoGroup(data);
+    fetchVideos();
+  }, [id, fetchVideos]);
+
+  useEffect(() => {
+    fetchVideoGroup();
+  }, [fetchVideoGroup]);
+
+  return { videoGroup, videos, setVideos, fetchVideos };
+}

--- a/frontendTS/src/hooks/useVideoUpload.ts
+++ b/frontendTS/src/hooks/useVideoUpload.ts
@@ -1,0 +1,155 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useNotification } from '../context/NotificationContext';
+import { createVideo } from '../services/api/videoService';
+import { getVideoGroup } from '../services/api/videoGroupService';
+
+interface UploadVideo {
+  file: File;
+  title: string;
+  positionInQueue: number;
+}
+
+export default function useVideoUpload(search: string) {
+  const [videoGroupId, setVideoGroupId] = useState<number | null>(null);
+  const [videoGroupName, setVideoGroupName] = useState('');
+  const [videos, setVideos] = useState<UploadVideo[]>([]);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const dropRef = useRef<HTMLDivElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const navigate = useNavigate();
+  const { t } = useTranslation(['videos', 'common']);
+  const { addNotification } = useNotification();
+
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+    const id = params.get('videogroupId');
+    if (!id) {
+      setError(t('errors.load_video_group'));
+      return;
+    }
+    const num = parseInt(id);
+    setVideoGroupId(num);
+    fetchVideoGroupName(num);
+  }, [search, t]);
+
+  const fetchVideoGroupName = async (id: number) => {
+    try {
+      const group = await getVideoGroup(id);
+      setVideoGroupName(group.name);
+    } catch {
+      setError(t('errors.load_video_group_details'));
+    }
+  };
+
+  const handleButtonClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFiles = Array.from(e.target.files || []);
+    processFiles(selectedFiles);
+  };
+
+  const processFiles = (files: File[]) => {
+    const accepted: UploadVideo[] = [];
+    const rejected: string[] = [];
+
+    files.forEach((file) => {
+      if (!file.type.startsWith('video/')) {
+        rejected.push(t('upload.error_not_video', { filename: file.name }));
+      } else if (file.size > 100 * 1024 * 1024) {
+        rejected.push(t('upload.error_size', { filename: file.name }));
+      } else {
+        accepted.push({
+          file,
+          title: file.name.replace(/\.[^/.]+$/, ''),
+          positionInQueue: videos.length + accepted.length + 1,
+        });
+      }
+    });
+
+    setVideos(prev => [...prev, ...accepted]);
+    if (rejected.length > 0) setError(rejected.join('\n'));
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const droppedFiles = Array.from(e.dataTransfer.files);
+    processFiles(droppedFiles);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => e.preventDefault();
+
+  const handleInputChange = (index: number, name: keyof UploadVideo, value: any) => {
+    setVideos(prev => {
+      const updated = [...prev];
+      // @ts-ignore
+      updated[index][name] = name === 'positionInQueue' ? parseInt(value) : value;
+      return updated;
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    setUploadProgress(0);
+
+    if (videos.length === 0 || !videoGroupId) {
+      setError(t('upload.error_empty'));
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const progressPerVideo = Array(videos.length).fill(0);
+
+      const uploadPromises = videos.map((video, index) => {
+        const formDataObj = new FormData();
+        formDataObj.append('Title', video.title);
+        formDataObj.append('VideoGroupId', videoGroupId.toString());
+        formDataObj.append('PositionInQueue', video.positionInQueue.toString());
+        formDataObj.append('File', video.file);
+
+        return createVideo(formDataObj, (progressEvent) => {
+          const percentCompleted = Math.round((progressEvent.loaded * 100) / progressEvent.total);
+          progressPerVideo[index] = percentCompleted;
+          const overallProgress = Math.round(progressPerVideo.reduce((a, b) => a + b, 0) / videos.length);
+          setUploadProgress(overallProgress);
+        });
+      });
+
+      await Promise.all(uploadPromises);
+      navigate(`/video-groups/${videoGroupId}`);
+    } catch (err: any) {
+      setError(err.response?.data?.message || t('upload.error_general'));
+      setLoading(false);
+    }
+  };
+
+  const handleRemove = (index: number) => {
+    setVideos(prev => prev.filter((_, i) => i !== index));
+  };
+
+  return {
+    videoGroupId,
+    videoGroupName,
+    videos,
+    error,
+    loading,
+    uploadProgress,
+    dropRef,
+    fileInputRef,
+    handleButtonClick,
+    handleFileSelect,
+    handleDrop,
+    handleDragOver,
+    handleInputChange,
+    handleSubmit,
+    handleRemove,
+  };
+}

--- a/frontendTS/src/models/AssignedLabel.ts
+++ b/frontendTS/src/models/AssignedLabel.ts
@@ -1,0 +1,11 @@
+export interface AssignedLabel {
+  id: number;
+  labelId: number;
+  labelName: string;
+  labelerName: string;
+  subjectName: string;
+  start: string;
+  end: string;
+  insDate: string;
+  videoId: number;
+}

--- a/frontendTS/src/pages/LabelAdd.tsx
+++ b/frontendTS/src/pages/LabelAdd.tsx
@@ -1,72 +1,14 @@
-import React, { useState, useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import React from "react";
+import { useLocation } from "react-router-dom";
 import "./css/ScientistProjects.css";
 import NavigateButton from "../components/NavigateButton";
-import { useNotification } from "../context/NotificationContext";
 import { useTranslation } from 'react-i18next';
-import { createLabel } from "../services/api/labelService";
-import { getSubject } from "../services/api/subjectService";
+import useLabelAdd from "../hooks/useLabelAdd";
 
 const LabelAdd = () => {
-  const [formData, setFormData] = useState({
-    name: "",
-    colorHex: "#3498db",
-    type: "range",
-    shortcut: "",
-    subjectId: null,
-  });
-  const [subjectName, setSubjectName] = useState("");
-  const navigate = useNavigate();
   const location = useLocation();
-  const { addNotification } = useNotification();
   const { t } = useTranslation(['labels', 'common']);
-
-  useEffect(() => {
-    const queryParams = new URLSearchParams(location.search);
-    const subjectId = queryParams.get("subjectId");
-
-    if (subjectId) {
-      setFormData((prev) => ({ ...prev, subjectId: parseInt(subjectId) }));
-      fetchSubjectName(parseInt(subjectId));
-    }
-  }, [location.search]);
-
-  const fetchSubjectName = async (id: number) => {
-    const subject = await getSubject(id);
-    setSubjectName(subject.name);
-  };
-
-  const handleChange = (e) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
-  };
-
-  const validateForm = () => {
-    if (formData.shortcut.length !== 1) {
-      addNotification(t('labels:notification.validation.shortcut'), "error");
-      return false;
-    }
-    if (!/^#[0-9A-Fa-f]{6}$/.test(formData.colorHex)) {
-      addNotification(t('labels:notification.validation.color'), "error");
-      return false;
-    }
-    if (!formData.name) {
-      addNotification(t('labels:notification.validation.name'), "error");
-      return false;
-    }
-    return true;
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    
-    if (!validateForm() || !formData.name || !formData.type || !formData.subjectId) {
-      return;
-    }
-    
-    await createLabel(formData);
-    navigate(`/subjects/${formData.subjectId}`);
-  };
+  const { formData, subjectName, handleChange, handleSubmit } = useLabelAdd(location.search);
 
   if (!formData.subjectId) {
     return (

--- a/frontendTS/src/pages/LabelEdit.tsx
+++ b/frontendTS/src/pages/LabelEdit.tsx
@@ -1,69 +1,13 @@
-import React, { useState, useEffect } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import React from "react";
+import { useParams } from "react-router-dom";
 import NavigateButton from "../components/NavigateButton";
 import { useTranslation } from 'react-i18next';
-import { useNotification } from "../context/NotificationContext";
-import { getLabel, updateLabel } from "../services/api/labelService";
-import { getSubject } from "../services/api/subjectService";
+import useLabelEdit from "../hooks/useLabelEdit";
 
 const LabelEdit = () => {
   const { id } = useParams();
-  const [labelData, setLabelData] = useState({
-    name: "",
-    colorHex: "#ffffff",
-    type: "range",
-    shortcut: "",
-    subjectId: null,
-  });
-  const [subjectName, setSubjectName] = useState("");
-  const navigate = useNavigate();
   const { t } = useTranslation(['labels', 'common']);
-  const { addNotification } = useNotification();
-
-  useEffect(() => {
-    const fetchLabelData = async () => {
-      if (!id) return;
-      const data = await getLabel(parseInt(id));
-      setLabelData(data);
-      fetchSubjectName(data.subjectId);
-    };
-
-    const fetchSubjectName = async (subjectId: number) => {
-      const subject = await getSubject(subjectId);
-      setSubjectName(subject.name);
-    };
-
-    if (id) fetchLabelData();
-  }, [id]);
-
-  const handleChange = (e) => {
-    const { name, value } = e.target;
-    setLabelData((prev) => ({ ...prev, [name]: value }));
-  };
-
-  const validateForm = () => {
-    if (labelData.shortcut.length !== 1) {
-      addNotification(t('labels:notification.validation.shortcut'), "error");
-      return false;
-    }
-    if (!/^#[0-9A-Fa-f]{6}$/.test(labelData.colorHex)) {
-      addNotification(t('labels:notification.validation.color'), "error");
-      return false;
-    }
-    if (!labelData.name) {
-      addNotification(t('labels:notification.validation.name'), "error");
-      return false;
-    }
-    return true;
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!validateForm()) return;
-    if (!id) return;
-    await updateLabel(parseInt(id), labelData);
-    navigate(`/subjects/${labelData.subjectId}`);
-  };
+  const { formData: labelData, subjectName, handleChange, handleSubmit } = useLabelEdit(id ? parseInt(id) : undefined);
 
   return (
       <div className="container py-4">

--- a/frontendTS/src/pages/LabelerVideoGroups.tsx
+++ b/frontendTS/src/pages/LabelerVideoGroups.tsx
@@ -1,98 +1,27 @@
-import React, { useState, useEffect } from "react";
-import { useParams, useNavigate } from "react-router-dom";
-import { getProjects, joinProject } from "../services/api/projectService";
-import { getAssignments } from "../services/api/assignmentService";
+import React from "react";
 import "./css/ScientistProjects.css";
 import NavigateButton from "../components/NavigateButton";
 import DataTable from "../components/DataTable";
-import { useNotification } from "../context/NotificationContext";
 import { useTranslation } from 'react-i18next';
+import useLabelerVideoGroups from "../hooks/useLabelerVideoGroups";
 
 const LabelerVideoGroups = () => {
-  const { labelerId } = useParams();
-  const [projects, setProjects] = useState([]);
-  const [assignments, setAssignments] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [accessCode, setAccessCode] = useState("");
-  const [expandedProjects, setExpandedProjects] = useState({});
-  const navigate = useNavigate();
-  const { addNotification } = useNotification();
   const { t } = useTranslation(['labeler', 'common']);
+  const {
+    projects,
+    loading,
+    accessCode,
+    setAccessCode,
+    expandedProjects,
+    toggleProjectExpand,
+    getProjectAssignments,
+    handleJoinProject,
+  } = useLabelerVideoGroups();
 
   const assignmentsColumns = [
     { field: "subjectName", header: t('labeler:projects.columns.subject') },
     { field: "videoGroupName", header: t('labeler:projects.columns.video_group') }
   ];
-
-  const handleJoinProject = async () => {
-    if (!accessCode.trim()) {
-      addNotification(t('labeler:join_project.required_code'), "error");
-      return;
-    }
-
-    try {
-      await joinProject(accessCode.trim());
-      addNotification(t('labeler:join_project.success'), "success");
-      setAccessCode("");
-      fetchProjects();
-    } catch (error) {
-      addNotification(
-          error.response?.data?.message || t('labeler:join_project.invalid_code'),
-          "error"
-      );
-    }
-  };
-
-  const fetchProjects = async () => {
-    setLoading(true);
-    try {
-      const response = await getProjects();
-      setProjects(response);
-      const expanded = {};
-      response.forEach((project) => {
-        expanded[project.id] = false;
-      });
-      setExpandedProjects(expanded);
-      await fetchAssignments();
-    } catch (error) {
-      addNotification(
-          error.response?.data?.message || t('labeler:errors.load_projects'),
-          "error"
-      );
-      setLoading(false);
-    }
-  };
-
-  const fetchAssignments = async () => {
-    try {
-      const response = await getAssignments();
-      setAssignments(response);
-    } catch (error) {
-      addNotification(
-          error.response?.data?.message || t('labeler:errors.load_assignments'),
-          "error"
-      );
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const toggleProjectExpand = (projectId) => {
-    setExpandedProjects((prev) => ({
-      ...prev,
-      [projectId]: !prev[projectId],
-    }));
-  };
-
-  const getProjectAssignments = (projectId) => {
-    return assignments.filter(
-      (assignment) => assignment.projectId === projectId
-    );
-  };
-
-  useEffect(() => {
-    fetchProjects();
-  }, [labelerId]);
 
   if (loading) {
     return (

--- a/frontendTS/src/pages/Login.tsx
+++ b/frontendTS/src/pages/Login.tsx
@@ -1,96 +1,14 @@
-import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import authService from "../auth";
-import { useAuth } from "../context/AuthContext";
-import { useNotification } from "../context/NotificationContext";
+import React from "react";
 import { useTranslation } from 'react-i18next';
+import useAuthForm from "../hooks/useAuthForm";
 import "./css/ScientistProjects.css";
 
-const roleMap = {
-    Labeler: "Labeler",
-    Scientist: "Scientist",
-};
 
 const AuthPage = () => {
-    const [isLoginView, setIsLoginView] = useState(true);
-    const [formData, setFormData] = useState({
-        username: "",
-        email: "",
-        password: "",
-        confirmPassword: "",
-        ScientistCreateToken: "",
-        role: "Labeler",
-    });
-    const [loading, setLoading] = useState(false);
-    const navigate = useNavigate();
-    const { addNotification } = useNotification();
     const { t } = useTranslation(['auth', 'common']);
-    const { handleLogin, roles, isAuthenticated } = useAuth();
-    const [loginSuccess, setLoginSuccess] = useState(false);
+    const { isLoginView, formData, loading, setIsLoginView, handleInputChange, handleSubmit } = useAuthForm();
 
-    const redirectIfAuthenticated = () => {
-        if (isAuthenticated) {
-            if (roles.includes("Scientist")) {
-                navigate("/projects");
-            } else if (roles.includes("Labeler")) {
-                navigate("/labeler-video-groups");
-            } else {
-                addNotification(t('auth:error.no_access'), "error");
-            }
-        }
-    };
-
-    useEffect(() => {
-        redirectIfAuthenticated();
-    }, [isAuthenticated, roles, navigate, t, addNotification]);
-
-    useEffect(() => {
-        if (loginSuccess) {
-            addNotification(t('auth:notification.login_success'), "success");
-            redirectIfAuthenticated();
-            setLoginSuccess(false);
-        }
-    }, [loginSuccess, roles, navigate, t, addNotification]);
-
-    const handleInputChange = (e) => {
-        setFormData({ ...formData, [e.target.name]: e.target.value });
-    };
-
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        setLoading(true);
-
-        if (!isLoginView && formData.password !== formData.confirmPassword) {
-            addNotification(t('auth:error.password_mismatch'), "error");
-            setLoading(false);
-            return;
-        }
-
-        try {
-            if (isLoginView) {
-                await handleLogin(formData.username, formData.password);
-                setLoginSuccess(true);
-            } else {
-                await authService.register({
-                    userName: formData.username,
-                    email: formData.email,
-                    password: formData.password,
-                    role: roleMap[formData.role],
-                    scientistCreateToken: formData.role === "Scientist" ? formData.ScientistCreateToken : undefined,
-                });
-                setIsLoginView(true);
-                setFormData({ ...formData, password: "", confirmPassword: "" });
-                addNotification(t('auth:notification.registration_success'), "success");
-            }
-        } catch (err) {
-            addNotification(
-                err.message || t(isLoginView ? 'auth:error.invalid_credentials' : 'auth:error.registration_failed'),
-                "error"
-            );
-        } finally {
-            setLoading(false);
-        }
-    };
+    // logic is encapsulated in useAuthForm hook
 
     return (
         <div className="container py-5" style={{ maxWidth: "600px" }}>

--- a/frontendTS/src/pages/ProjectDetails.tsx
+++ b/frontendTS/src/pages/ProjectDetails.tsx
@@ -1,68 +1,19 @@
-import React, { useState, useEffect } from "react";
-import { useParams, useLocation } from "react-router-dom";
-import { getProject, getProjectReports } from "../services/api/projectService";
+import React from "react";
+import { useParams } from "react-router-dom";
 import "./css/ScientistProjects.css";
-import { getSignalRService } from "../services/SignalRServiceInstance";
-import { useNotification } from "../context/NotificationContext";
 import { useTranslation } from 'react-i18next';
+import useProjectDetails from "../hooks/useProjectDetails";
 import ProjectDetailsTab from "../components/project-tabs/ProjectDetailsTab";
 import ProjectSubjectsTab from "../components/project-tabs/ProjectSubjectsTab";
 import ProjectVideosTab from "../components/project-tabs/ProjectVideosTab";
 import ProjectAssignmentsTab from "../components/project-tabs/ProjectAssignmentsTab";
 import ProjectLabelersTab from "../components/project-tabs/ProjectLabelersTab";
 import ProjectAccessCodesTab from "../components/project-tabs/ProjectAccessCodesTab";
-import { MessageTypes } from "../config/messageTypes";
 
 const ProjectDetails = () => {
   const { id } = useParams();
-  const [project, setProject] = useState(null);
-  const [reports, setReports] = useState([]);
-  const [activeTab, setActiveTab] = useState("details");
-  const [labelersCount, setLabelersCount] = useState(0);
-  const { addNotification } = useNotification();
   const { t } = useTranslation(['projects', 'common']);
-
-  useEffect(() => {
-    const startSignalR = async () => {
-      const signalRService = getSignalRService(addNotification);
-      signalRService.onMessage(MessageTypes.LabelersCountChanged, (msg) => {
-        setLabelersCount(msg);
-      });
-      signalRService.onMessage(MessageTypes.ReportGenerated, () => {
-        fetchReports();
-      });
-    };
-    startSignalR();
-  }, [id]);
-
-  const fetchReports = async () => {
-    if (!id) return;
-    const data = await getProjectReports(parseInt(id));
-    setReports(data);
-  };
-
-  const fetchBasicProjectData = async () => {
-    if (!id) return;
-    const projectRes = await getProject(parseInt(id));
-    setProject(projectRes);
-    await fetchReports();
-  };
-
-  useEffect(() => {
-    fetchBasicProjectData();
-  }, [id]);
-
-  useEffect(() => {
-    const cachedTab = localStorage.getItem(`project_${id}_activeTab`);
-    if (cachedTab) {
-      setActiveTab(cachedTab);
-    }
-  }, [id]);
-  
-  const handleTabChange = (tabName) => {
-    setActiveTab(tabName);
-    localStorage.setItem(`project_${id}_activeTab`, tabName);
-  };
+  const { project, reports, activeTab, handleTabChange, labelersCount, setLabelersCount, fetchReports } = useProjectDetails(id ? parseInt(id) : undefined);
 
   if (!project) {
     return (

--- a/frontendTS/src/pages/SubjectDetails.tsx
+++ b/frontendTS/src/pages/SubjectDetails.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useState, useEffect } from "react";
+﻿import React from "react";
 import { useParams } from "react-router-dom";
 import NavigateButton from "../components/NavigateButton";
 import DeleteButton from "../components/DeleteButton";
@@ -6,14 +6,14 @@ import DataTable from "../components/DataTable";
 import "./css/ScientistProjects.css";
 import { useTranslation } from 'react-i18next';
 import useSubject from "../hooks/useSubject";
-import { getSubjectLabels } from "../services/api/subjectService";
 import { deleteLabel } from "../services/api/labelService";
+import useSubjectLabels from "../hooks/useSubjectLabels";
 
 const SubjectDetails = () => {
   const { t } = useTranslation(['subjects', 'common']);
   const { id } = useParams();
   const { subject } = useSubject(id ? parseInt(id) : undefined);
-  const [labels, setLabels] = useState([]);
+  const { labels, fetchLabels } = useSubjectLabels(id ? parseInt(id) : undefined);
 
   const labelColumns = [
     { field: "name", header: t('subjects:columns.name') },
@@ -36,15 +36,7 @@ const SubjectDetails = () => {
     },
   ];
 
-  const fetchLabels = async () => {
-    if (!id) return;
-    const data = await getSubjectLabels(parseInt(id));
-    setLabels(data.filter(l => l.subjectId === parseInt(id)).sort((a, b) => a.id - b.id));
-  };
 
-  useEffect(() => {
-    fetchLabels();
-  }, [id]);
 
   const handleDeleteLabel = async (labelId: number) => {
     await deleteLabel(labelId);

--- a/frontendTS/src/pages/SubjectVideoGroupAssignmentAdd.tsx
+++ b/frontendTS/src/pages/SubjectVideoGroupAssignmentAdd.tsx
@@ -1,60 +1,14 @@
-import React, { useState, useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import React from "react";
+import { useLocation } from "react-router-dom";
 import "./css/ScientistProjects.css";
 import NavigateButton from "../components/NavigateButton";
 import { useTranslation } from 'react-i18next';
-import { getProjectSubjects, getProjectVideoGroups } from "../services/api/projectService";
-import { createAssignment } from "../services/api/assignmentService";
+import useAssignmentAdd from "../hooks/useAssignmentAdd";
 
 const SubjectVideoGroupAssignmentAdd = () => {
   const { t } = useTranslation(['assignments', 'common']);
-  const [formData, setFormData] = useState({
-    subjectId: "",
-    videoGroupId: "",
-  });
-  const [subjects, setSubjects] = useState([]);
-  const [videoGroups, setVideoGroups] = useState([]);
-  const [projectId, setProjectId] = useState(null);
-  const navigate = useNavigate();
   const location = useLocation();
-
-  useEffect(() => {
-    const queryParams = new URLSearchParams(location.search);
-    const projectIdParam = queryParams.get("projectId");
-    if (projectIdParam) {
-      setProjectId(parseInt(projectIdParam));
-      fetchSubjectsAndVideoGroups(parseInt(projectIdParam));
-    }
-  }, [location.search]);
-
-  const fetchSubjectsAndVideoGroups = async (projectId: number) => {
-    const [subjectsData, videoGroupsData] = await Promise.all([
-      getProjectSubjects(projectId),
-      getProjectVideoGroups(projectId),
-    ]);
-
-    setSubjects(subjectsData);
-    setVideoGroups(videoGroupsData);
-  };
-
-  const handleChange = (e) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
-  };
-
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-
-    if (!formData.subjectId || !formData.videoGroupId) {
-      return;
-    }
-
-    await createAssignment({
-      subjectId: parseInt(formData.subjectId),
-      videoGroupId: parseInt(formData.videoGroupId),
-    });
-    navigate(`/projects/${projectId}`);
-  };
+  const { formData, subjects, videoGroups, projectId, handleChange, handleSubmit } = useAssignmentAdd(location.search);
 
   return (
     <div className="container py-4">

--- a/frontendTS/src/pages/SubjectVideoGroupAssignmentDetails.tsx
+++ b/frontendTS/src/pages/SubjectVideoGroupAssignmentDetails.tsx
@@ -1,55 +1,29 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import "./css/ScientistProjects.css";
 import DeleteButton from "../components/DeleteButton";
 import DataTable from "../components/DataTable";
 import NavigateButton from "../components/NavigateButton";
 import { useTranslation } from 'react-i18next';
-import { getAssignment, deleteAssignment, getAssignmentLabelers } from "../services/api/assignmentService";
-import { getSubject } from "../services/api/subjectService";
-import { getVideoGroup } from "../services/api/videoGroupService";
+import useAssignmentDetails from "../hooks/useAssignmentDetails";
 
 const SubjectVideoGroupAssignmentDetails = () => {
   const { t } = useTranslation(['assignments', 'common']);
   const { id } = useParams();
   const navigate = useNavigate();
-  const [assignmentDetails, setAssignmentDetails] = useState(null);
-  const [subject, setSubject] = useState(null);
-  const [videoGroup, setVideoGroup] = useState(null);
-  const [labelers, setLabelers] = useState([]);
+  const { assignment, subject, videoGroup, labelers, fetchData, handleDelete } = useAssignmentDetails(id ? parseInt(id) : undefined);
 
   const labelerColumns = [
     { field: "name", header: t('assignments:columns.name') },
   ];
 
-  const fetchData = async () => {
-    if (!id) return;
-    const assignment = await getAssignment(parseInt(id));
-    setAssignmentDetails(assignment);
-
-    const [subjectData, videoGroupData, labelersData] = await Promise.all([
-      getSubject(assignment.subjectId),
-      getVideoGroup(assignment.videoGroupId),
-      getAssignmentLabelers(parseInt(id)),
-    ]);
-
-    setSubject(subjectData);
-    setVideoGroup(videoGroupData);
-    setLabelers(labelersData);
-  };
-
-  useEffect(() => {
-    if (id) fetchData();
-  }, [id]);
-
-  const handleDelete = async () => {
+  const onDelete = async () => {
     if (!window.confirm(t('assignments:confirm.delete'))) return;
-    if (!id) return;
-    await deleteAssignment(parseInt(id));
+    await handleDelete();
     navigate(-1);
   };
 
-  if (!assignmentDetails) {
+  if (!assignment) {
     return null;
   }
 
@@ -59,14 +33,14 @@ const SubjectVideoGroupAssignmentDetails = () => {
         <div className="col">
           <div className="d-flex justify-content-between align-items-center">
             <h1 className="heading mb-0">
-              {t('assignments:details.title', { id: assignmentDetails.id })}
+              {t('assignments:details.title', { id: assignment.id })}
             </h1>
             <div className="d-flex justify-content-end">
-              <DeleteButton onConfirm={handleDelete} />
+              <DeleteButton onConfirm={onDelete} />
               <button className="btn btn-secondary me-2 text-nowrap" onClick={fetchData}>
                 <i className="fas fa-sync-alt me-1"></i> {t('common:buttons.refresh')}
               </button>
-              <NavigateButton path={`/projects/${assignmentDetails.projectId}`} actionType="Back" />
+              <NavigateButton path={`/projects/${assignment.projectId}`} actionType="Back" />
             </div>
           </div>
         </div>

--- a/frontendTS/src/pages/VideoDetails.tsx
+++ b/frontendTS/src/pages/VideoDetails.tsx
@@ -1,43 +1,16 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useRef } from "react";
 import { useParams } from "react-router-dom";
 import "./css/ScientistProjects.css";
 import DataTable from "../components/DataTable";
 import NavigateButton from "../components/NavigateButton";
 import { useTranslation } from "react-i18next";
-import { getVideo, getVideoStream, getAssignedLabels } from "../services/api/videoService";
+import useVideoDetails from "../hooks/useVideoDetails";
 
 const VideoDetails = () => {
-    const { id: videoId } = useParams();
-    const [videoData, setVideoData] = useState(null);
-    const [videoStream, setVideoStream] = useState(null);
-    const [labels, setLabels] = useState([]);
+    const { id } = useParams();
     const videoRef = useRef(null);
     const { t } = useTranslation(['videos', 'common']);
-
-    useEffect(() => {
-        fetchVideoDetails(videoId);
-        fetchVideoStream(videoId);
-        fetchAssignedLabels(videoId);
-    }, [videoId]);
-
-    const fetchVideoDetails = async (videoId: string | undefined) => {
-        if (!videoId) return;
-        const data = await getVideo(parseInt(videoId));
-        setVideoData(data);
-    };
-
-    async function fetchVideoStream(videoId) {
-        if (!videoId) return;
-        const blob = await getVideoStream(parseInt(videoId));
-        const streamUrl = URL.createObjectURL(blob);
-        setVideoStream(streamUrl);
-    }
-
-    const fetchAssignedLabels = async (videoId: string | undefined) => {
-        if (!videoId) return;
-        const data = await getAssignedLabels(parseInt(videoId));
-        setLabels(data);
-    };
+    const { video, stream, labels, loading } = useVideoDetails(id ? parseInt(id) : undefined);
 
     const labelColumns = [
         { field: "labelName", header: t('table.label') },
@@ -53,17 +26,17 @@ const VideoDetails = () => {
         { field: "videoId", header: t('table.videoId')}
     ];
 
-    if (!videoData) {
+    if (loading || !video) {
         return <div className="container text-center">{t('details.loading')}</div>;
     }
 
     return (
         <div className="container">
             <div className="d-flex justify-content-end mb-3">
-                <NavigateButton path={`/video-groups/${videoData.videoGroupId}`} actionType="Back" />
+                <NavigateButton path={`/video-groups/${video.videoGroupId}`} actionType="Back" />
             </div>
 
-            <h1 className="text-center mb-4">{videoData.title}</h1>
+            <h1 className="text-center mb-4">{video.title}</h1>
 
             <div
                 className="video-container mb-4"
@@ -80,7 +53,7 @@ const VideoDetails = () => {
                         objectFit: "contain",
                     }}
                     controls
-                    src={videoStream}
+                    src={stream}
                     type="video/mp4"
                 />
             </div>

--- a/frontendTS/src/pages/VideoGroupsDetails.tsx
+++ b/frontendTS/src/pages/VideoGroupsDetails.tsx
@@ -1,36 +1,17 @@
-﻿import React, { useState, useEffect } from "react";
+﻿import React from "react";
 import { useParams } from "react-router-dom";
-import { API_BASE_URL } from "../httpclient";
 import DeleteButton from "../components/DeleteButton";
 import "./css/ScientistProjects.css";
 import NavigateButton from "../components/NavigateButton";
 import DataTable from "../components/DataTable";
 import { useTranslation } from "react-i18next";
-import { getVideoGroup, getVideoGroupVideos } from "../services/api/videoGroupService";
 import { deleteVideo } from "../services/api/videoService";
+import useVideoGroupDetails from "../hooks/useVideoGroupDetails";
 
 const VideoGroupDetails = () => {
   const { id } = useParams();
-  const [videoGroupDetails, setVideoGroupDetails] = useState(null);
-  const [videos, setVideos] = useState([]);
   const { t } = useTranslation(['videos', 'common']);
-
-  async function fetchVideoGroupDetails() {
-    if (!id) return;
-    const data = await getVideoGroup(parseInt(id));
-    setVideoGroupDetails(data);
-    fetchVideos();
-  }
-
-  async function fetchVideos() {
-    if (!id) return;
-    const data = await getVideoGroupVideos(parseInt(id));
-    setVideos(data);
-  }
-
-  useEffect(() => {
-    if (id) fetchVideoGroupDetails();
-  }, [id]);
+  const { videoGroup, videos, setVideos } = useVideoGroupDetails(id ? parseInt(id) : undefined);
 
   const handleDeleteVideo = async (videoId: number) => {
     await deleteVideo(videoId);
@@ -42,12 +23,12 @@ const VideoGroupDetails = () => {
     { field: "positionInQueue", header: t('videos:table.position') },
   ];
 
-  if (!videoGroupDetails) return null;
+  if (!videoGroup) return null;
 
   return (
     <div className="container">
       <div className="content">
-        <h1 className="heading mb-4">{videoGroupDetails.name}</h1>
+        <h1 className="heading mb-4">{videoGroup.name}</h1>
 
         <div className="d-flex justify-content-between mb-4">
           <NavigateButton
@@ -55,7 +36,7 @@ const VideoGroupDetails = () => {
             actionType="Add"
             value={t('common:buttons.add')}
           />
-          <NavigateButton path={`/projects/${videoGroupDetails.projectId}`} actionType="Back" value={t('common:buttons.back')} />
+          <NavigateButton path={`/projects/${videoGroup.projectId}`} actionType="Back" value={t('common:buttons.back')} />
         </div>
 
         {videos.length > 0 ? (


### PR DESCRIPTION
## Summary
- extract logic from remaining pages into reusable hooks
- introduce hooks for labels, projects, assignments and uploads
- simplify page components to focus on rendering

## Testing
- `npm run lint` *(fails: Missing script: "lint")*